### PR TITLE
Added detection for Heroku

### DIFF
--- a/takeover.py
+++ b/takeover.py
@@ -27,6 +27,7 @@ services = {
 	'Fastly'     : {'code':'[300-499]','error':r'Fastly error\: unknown domain\:'},
 	'FeedPress'  : {'code':'[300-499]','error':r'The feed has not been found\.'},
 	'Ghost'      : {'code':'[300-499]','error':r'The thing you were looking for is no longer here\, or never was'},
+	'Heroku'     : {'code':'[300-499]','error':r'no-such-app.html'},
 }
 
 # -- colors 


### PR DESCRIPTION
The page that will be returned for a vulnerable Heroku subdomain is below. Heroku returns a 404 when delivering this page. I validated this works on a known vulnerable subdomain, but I unfortunately can't provide those details.

<!DOCTYPE html>
	<html>
	  <head>
		<meta name="viewport" content="width=device-width, initial-scale=1">
		<meta charset="utf-8">
		<title>No such app</title>
		<style media="screen">
		  html,body,iframe {
			margin: 0;
			padding: 0;
		  }
		  html,body {
			height: 100%;
			overflow: hidden;
		  }
		  iframe {
			width: 100%;
			height: 100%;
			border: 0;
		  }
		</style>
	  </head>
	  <body>
		<iframe src="//www.herokucdn.com/error-pages/no-such-app.html"></iframe>
	  </body>
	</html>
