### PR TITLE
fixed dockerfile not building

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='takeover',
       scripts=['takeover.py'],
       install_requires=[
           'requests',
-          'urllib3',
+          'urllib3<1.27',
       ],
       entry_points={
           'console_scripts': ['takeover=takeover:main'],


### PR DESCRIPTION
At the moment, Takeover will not build due to the `setup.py` not pinning dependencies. When attempting to install the tool, it exits with this error:

```
error: urllib3 2.0.0a1 is installed but urllib3<1.27,>=1.21.1 is required by {'requests'}
```

So this PR pins `urllib3`'s version in `setup.py` so this issue isn't encountered.


Signed-off-by: Spencer Heywood <l.spencer.heywood@protonmail.com>